### PR TITLE
refactor fix: tabbed out awesome_print require in nytimes.rb

### DIFF
--- a/lib/nytimes.rb
+++ b/lib/nytimes.rb
@@ -1,4 +1,4 @@
-require 'awesome_print'
+# require 'awesome_print'
 
 class Nytimes
   DATA = {


### PR DESCRIPTION
initial commit with lib/nytimes.rb require fix